### PR TITLE
BREAKING chore(cli): rename `--map` to `--import-map`

### DIFF
--- a/act.test.ts
+++ b/act.test.ts
@@ -43,7 +43,7 @@ Deno.test("act()", async (test) => {
     defaults.config = false;
     defaults.configOnly = false;
     defaults.git = false;
-    defaults.map = false;
+    defaults.importMap = false;
   };
 
   await test.step(
@@ -70,11 +70,11 @@ Deno.test("act()", async (test) => {
   );
 
   await test.step(
-    "create import_map.json if settings.map is true",
+    "create import_map.json if settings.importMap is true",
     async () => {
       await beforeEach();
 
-      defaults.map = true;
+      defaults.importMap = true;
 
       await act(defaults);
 

--- a/act.ts
+++ b/act.ts
@@ -21,7 +21,7 @@ export async function act(settings: Settings) {
     await Deno.mkdir(path, { recursive: true });
   }
 
-  if (settings.map) {
+  if (settings.importMap) {
     await settings.addProjectFile(
       `${path}/import_map.json`,
       settings.mapContent,

--- a/ask.ts
+++ b/ask.ts
@@ -22,7 +22,7 @@ export function ask(options: any) {
   ) ?? "dev_deps";
 
   let map = false;
-  if (!options.map) {
+  if (!options.importMap) {
     const importMap = prompt(
       "Add import map?",
       "n",

--- a/init.ts
+++ b/init.ts
@@ -26,7 +26,7 @@ await new Command()
     "Force overwrite of existing files/directories. Helpful to re-initialize, but use with caution!",
   )
   .option(
-    "-m, --map [map:boolean]",
+    "-m, --import-map [importMap:boolean]",
     "Add an import map as part of the project.",
     {
       default: false,
@@ -69,4 +69,15 @@ await new Command()
       act({ ...defaults, ...options });
     }
   })
+  .help({
+    hints: false,
+  })
+  .example(
+    "Start a test-driven project",
+    "mod --tdd",
+  )
+  .example(
+    "Create a project with an import map and deno configuration file",
+    "mod --import-map -config",
+  )
   .parse(Deno.args);

--- a/settings.ts
+++ b/settings.ts
@@ -15,7 +15,7 @@ export interface FlagSettings {
   configOnly: boolean;
   force: boolean;
   git: boolean;
-  map: boolean;
+  importMap: boolean;
   tdd: boolean;
 }
 
@@ -72,7 +72,7 @@ target/`,
   ),
   moduleContent: defaultModuleContent,
   name: ".",
-  map: false,
+  importMap: false,
   mapContent: encoder.encode(
     `{
   "imports": {}


### PR DESCRIPTION
This expresses intent more clearly, but it will break existing uses where the CLI is run with `--map`