### PR TITLE
chore: make generated workflow more concise

### DIFF
--- a/settings.ts
+++ b/settings.ts
@@ -102,26 +102,21 @@ export const actions = encoder.encode(YAML.stringify({
       },
       steps: [
         {
-          name: "Set up Actions",
           uses: "actions/checkout@v2",
         },
         {
-          name: "Set up Deno",
           uses: "denoland/setup-deno@v1.1.0",
           with: {
             "deno-version": "v1.x.x",
           },
         },
         {
-          name: "Check format",
           run: "deno fmt --check",
         },
         {
-          name: "Check code issues",
           run: "deno lint",
         },
         {
-          name: "Run tests and collect code coverage",
           run: "deno test -A --coverage=cov",
         },
       ],


### PR DESCRIPTION
Reasoning behind this change is that most users will prefer to write their own comments, if any, in their workflow. This keeps the CI generated with `--ci` very compact and reduces some boilerplate comments that people may not want/need