### PR TITLE
feat(ci): cache test dependencies to speed up workflow runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: deno fmt --check
       - run: deno lint
       #- run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
-      - run: deno test -A --coverage=cov --unstable --cached-only
+      - run: deno test -A --coverage=cov --unstable
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,10 +38,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-deno3
+          key: ${{ runner.os }}-deno
 
-     # - run: deno fmt --check
-     # - run: deno lint
+      - run: deno fmt --check --ignore $DENO_DIR
+      - run: deno lint
       # - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
       - name: test
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,16 +31,18 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         run: DENO_DIR=deno_cache
 
-      - run: deno fmt --check
-      - run: deno lint
-      - run: deno test -A --coverage=cov --unstable
-
       - name: Cache DENO_DIR
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/cache@v2
         with:
           path: deno_cache
-          # key: ${{ runner.os }}-denocache
+          key: ${{ runner.os }}-deno
+
+      - run: deno fmt --check
+      - run: deno lint
+      - run: deno test -A --coverage=cov --unstable
+
+
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,8 +40,8 @@ jobs:
 
       - run: deno fmt --check
       - run: deno lint
-      - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
-      # - run: deno test -A --coverage=cov --unstable --cached-only
+      #- run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
+      - run: deno test -A --coverage=cov --unstable --cached-only
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-deno
+          key: ${{ runner.os }}-deno-caching-key
 
       - name: test
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,9 +41,6 @@ jobs:
 
       - name: test
         run: |
-          deno info
-          DENO_DIR=deno_cache
-          deno info
           deno test -A --coverage=cov --unstable
 
       - if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,19 @@ jobs:
       - uses: denoland/setup-deno@v1.1.0
         with:
           deno-version: ${{ matrix.deno-version }}
+
+      - name: Set Deno cache directory
+        run: DENO_DIR=deno_cache
+
       - run: deno fmt --check
       - run: deno lint
       - run: deno test -A --coverage=cov --unstable
+
+      - name: Cache DENO_DIR
+        uses: actions/cache@v2
+        with:
+          path: deno_cache
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,12 +40,14 @@ jobs:
           path: deno_cache
           key: ${{ runner.os }}-deno3
 
-      - run: deno fmt --check
-      - run: deno lint
+     # - run: deno fmt --check
+     # - run: deno lint
       # - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
       - name: test
         run: |
+          deno info
           DENO_DIR=deno_cache
+          deno info
           deno test -A --coverage=cov --unstable
 
       - if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,8 @@ jobs:
 
       - run: deno fmt --check
       - run: deno lint
-      - run: deno test -A --coverage=cov --unstable --cached-only
+      - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
+      # - run: deno test -A --coverage=cov --unstable --cached-only
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set Deno cache directory
         if: matrix.os == 'ubuntu-20.04'
-        run: DENO_DIR=deno_cache
+        run: export DENO_DIR=deno_cache
 
       - name: Cache DENO_DIR
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,9 +29,8 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
 
-      # - name: Set Deno cache directory
-      #   if: matrix.os == 'ubuntu-20.04'
-      #   run: export 
+      - run: deno fmt --check
+      - run: deno lint
 
       - name: Cache DENO_DIR
         if: matrix.os == 'ubuntu-20.04'
@@ -40,9 +39,6 @@ jobs:
           path: deno_cache
           key: ${{ runner.os }}-deno
 
-      - run: deno fmt --check --ignore $DENO_DIR
-      - run: deno lint
-      # - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
       - name: test
         run: |
           deno info

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,12 +36,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-deno
+          key: ${{ runner.os }}-deno2
 
       - run: deno fmt --check
       - run: deno lint
-      #- run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
-      - run: |
+      # - run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
+      - name: test
+        run: |
           DENO_DIR=deno_cache
           deno test -A --coverage=cov --unstable
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: matrix.os == 'ubuntu-20.04'
         uses: actions/cache@v2
         with:
-          path: deno_cache
+          path: depcache
           key: ${{ runner.os }}-deno-caching-key
 
       - name: test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-denocache
+          # key: ${{ runner.os }}-denocache
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,9 +40,7 @@ jobs:
 
       - run: deno fmt --check
       - run: deno lint
-      - run: deno test -A --coverage=cov --unstable
-
-
+      - run: deno test -A --coverage=cov --unstable --cached-only
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,8 @@ jobs:
           - deno-version: canary
             os: ubuntu-18.04
             experimental: true
+    env:
+      DENO_DIR: depcache
           
     steps:
       - name: Configure line-endings for Windows builds
@@ -36,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-deno2
+          key: ${{ runner.os }}-deno3
 
       - run: deno fmt --check
       - run: deno lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,7 @@ jobs:
           deno-version: ${{ matrix.deno-version }}
 
       - name: Set Deno cache directory
+        if: matrix.os == 'ubuntu-20.04'
         run: DENO_DIR=deno_cache
 
       - run: deno fmt --check
@@ -35,10 +36,11 @@ jobs:
       - run: deno test -A --coverage=cov --unstable
 
       - name: Cache DENO_DIR
+        if: matrix.os == 'ubuntu-20.04'
         uses: actions/cache@v2
         with:
           path: deno_cache
-          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+          key: ${{ runner.os }}-denocache
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,3 +51,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: cov.lcov
+          

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,9 +27,9 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
 
-      - name: Set Deno cache directory
-        if: matrix.os == 'ubuntu-20.04'
-        run: export DENO_DIR=deno_cache
+      # - name: Set Deno cache directory
+      #   if: matrix.os == 'ubuntu-20.04'
+      #   run: export 
 
       - name: Cache DENO_DIR
         if: matrix.os == 'ubuntu-20.04'
@@ -41,7 +41,9 @@ jobs:
       - run: deno fmt --check
       - run: deno lint
       #- run: deno run https://deno.land/std@0.117.0/examples/welcome.ts
-      - run: deno test -A --coverage=cov --unstable
+      - run: |
+          DENO_DIR=deno_cache
+          deno test -A --coverage=cov --unstable
 
       - if: matrix.os == 'ubuntu-20.04'
         run: deno coverage --lcov cov > cov.lcov


### PR DESCRIPTION
Adds a GitHub cache action that caches the DENO_DIR so subsequent workflow runs don't need to re-download all the test dependencies
