### PR TITLE
fix: use the right dev deps entrypoint if a custom name is chosen in prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ https://deno.land/x/mod/mod.ts `
 release from `deno.land/x`:
 
 ```console
-deno install --allow-read --allow-run=git --allow-write -fn mod https://deno.land/x/mod@v2.2.16/mod.ts
+deno install --allow-read --allow-run=git --allow-write -fn mod https://deno.land/x/mod@v2.2.17/mod.ts
 ```
 
 You can also get the _unstable_ canary release from GitHub by installing via the

--- a/act.test.ts
+++ b/act.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertThrows, sinon } from "./dev_deps.ts";
-import { act, funcs } from "./act.ts";
+import { act, fns } from "./act.ts";
 import { settings } from "./settings.ts";
 
 Deno.test("runCommand()", async (test) => {
@@ -9,7 +9,7 @@ Deno.test("runCommand()", async (test) => {
     "return true if git initialization succeeds",
     async () => {
       Deno.mkdirSync(settings.name, { recursive: true });
-      assertEquals(await funcs.initGit(settings.name), true);
+      assertEquals(await fns.initGit(settings.name), true);
       Deno.removeSync(settings.name, { recursive: true });
     },
   );
@@ -18,9 +18,9 @@ Deno.test("runCommand()", async (test) => {
 Deno.test("act()", async (context) => {
   settings.name = "test_directory_act";
 
-  const fileSpy = sinon.spy(funcs, "addModuleFile");
+  const fileSpy = sinon.spy(fns, "writeFileSec");
 
-  const gitSpy = sinon.spy(funcs, "initGit");
+  const gitSpy = sinon.spy(fns, "initGit");
 
   const beforeEach = () => {
     Deno.mkdirSync(settings.name, { recursive: true });
@@ -35,6 +35,7 @@ Deno.test("act()", async (context) => {
     settings.importMap = false;
     settings.tdd = false;
     settings.ci = false;
+    settings.js = false;
 
     fileSpy.resetHistory();
     gitSpy.resetHistory();

--- a/act.ts
+++ b/act.ts
@@ -107,6 +107,10 @@ export async function act(settings: Settings) {
           /\{\{extension\}\}/,
           settings.extension,
         )
+        .replace(
+          /\{\{devDepsEntrypoint\}\}/,
+          settings.devDepsEntrypoint,
+        ),
     );
 
     await fns.writeFileSec(

--- a/ask.ts
+++ b/ask.ts
@@ -7,8 +7,8 @@ export function ask(settings: Settings): Settings {
   // Apply modifications to a clone of the settings object for isolation purposes.
   const userSettings: Settings = self.structuredClone(settings);
 
-  if (!settings.js) {
-    const ts = prompt("Use TypeScript?", "y");
+  if (!userSettings.js) {
+    const ts = prompt("Would you like to use TypeScript?", "y");
     userSettings.extension = (ts === "y" || ts === "Y") ? "ts" : "js";
   } else {
     userSettings.extension = "js";
@@ -44,7 +44,7 @@ export function ask(settings: Settings): Settings {
 
   if (!userSettings.importMap) {
     const importMap = prompt(
-      "Add import map?",
+      "Would you like to use an import map?",
       "n",
     );
     userSettings.importMap = importMap === "y" || importMap === "Y";
@@ -52,7 +52,7 @@ export function ask(settings: Settings): Settings {
 
   if (!userSettings.config) {
     const withConfig = prompt(
-      "Add Deno configuration file?",
+      "Would you like to use a Deno configuration file?",
       "n",
     );
     userSettings.config = withConfig === "y" || withConfig === "Y";

--- a/egg.json
+++ b/egg.json
@@ -3,7 +3,7 @@
   "entry": "./mod.ts",
   "description": "Start a new Deno module",
   "unstable": true,
-  "version": "v2.2.16",
+  "version": "v2.2.17",
   "files": [
     "./**/*.ts",
     "./README.md",

--- a/init.ts
+++ b/init.ts
@@ -3,7 +3,11 @@ import { act } from "./act.ts";
 import { settings } from "./settings.ts";
 import { ask } from "./ask.ts";
 import { validateOptions } from "./validate_options.ts";
+import { asciiDeno } from "./ascii.ts";
 
+/**
+ * The main CLI command with flags and options.
+ */
 await new Command()
   .name("mod")
   .version("v2.2.16")
@@ -86,6 +90,10 @@ await new Command()
       await act({ ...settings, ...options });
     }
 
+    if (options.ascii) {
+      drawDeno();
+    }
+
     if (options.name === "." || options.name === "./") {
       console.log(`Created new Deno module in current working directory.`);
     } else {
@@ -115,3 +123,17 @@ await new Command()
     "mod --import-map --config",
   )
   .parse(Deno.args);
+
+/**
+ * Responsible for drawing an ASCII-style Deno to the terminal if the user passes the --ascii option.
+ */
+function drawDeno() {
+  const lines = asciiDeno.split(/\n/);
+  let i = 0;
+  for (const line of lines) {
+    i += 50;
+    setTimeout(() => {
+      console.log(line);
+    }, 250 + i);
+  }
+}

--- a/init.ts
+++ b/init.ts
@@ -10,7 +10,7 @@ import { asciiDeno } from "./ascii.ts";
  */
 await new Command()
   .name("mod")
-  .version("v2.2.16")
+  .version("v2.2.17")
   .description("Start a new Deno module with a single command")
   .option(
     "--js [js:boolean]",

--- a/settings.ts
+++ b/settings.ts
@@ -75,7 +75,7 @@ target/`,
 };
 
 export const defaultTestModuleContent = encoder.encode(
-  `import { assert } from "./${settings.devDepsEntrypoint}.{{extension}}"; 
+  `import { assert } from "./{{devDepsEntrypoint}}.{{extension}}"; 
 
 Deno.test({
   name: "name",

--- a/utils.test.ts
+++ b/utils.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertThrows } from "./dev_deps.ts";
-import { hasNoFileExtension, writeFileSec } from "./utils.ts";
+import { writeFileSec } from "./utils.ts";
 
 Deno.test("writeFileOrWarn()", async (t) => {
   const testFilePath = "./foo.ts";
@@ -66,12 +66,4 @@ Deno.test("mkdirOrWarn()", async (t) => {
       await afterEach();
     },
   );
-});
-
-Deno.test("hasFileExtension()", async (t) => {
-  await t.step("should validate a filename correctly", () => {
-    assertEquals(hasNoFileExtension("mod.ts", "ts"), false);
-    assertEquals(hasNoFileExtension("mod.ts", "js"), true);
-    assertEquals(hasNoFileExtension("mod", "ts"), true);
-  });
 });

--- a/utils.ts
+++ b/utils.ts
@@ -5,7 +5,10 @@ export interface WriteFileSecOptions extends Deno.WriteFileOptions {
 }
 
 /**
- * Attempts to write to a file, but warns instead of overwrites if it already exists.
+ * Responsible for writing data to a file, but instead of overwriting by default
+ * it gives a warning if the file already exists.
+ *
+ * If `force: true` is passed, the file will be (over)written in any case.
  */
 export async function writeFileSec(
   path: string | URL,
@@ -26,11 +29,4 @@ export async function writeFileSec(
   } catch (_error) {
     await Deno.writeFile(path, data, options);
   }
-}
-
-export function hasNoFileExtension(
-  filename: string,
-  extension: string,
-): boolean {
-  return !new RegExp(`\.${extension}$`).test(filename);
 }

--- a/validate_options.ts
+++ b/validate_options.ts
@@ -9,7 +9,7 @@ export function validateOptions(options: Settings) {
       options.importMap || options.js)
   ) {
     throw new Error(
-      "Cannot use --config-only in combination with other options other than --name.",
+      "Cannot use '--config-only' with other options except '--name.'",
     );
   }
 }


### PR DESCRIPTION
This fixes a bug where if `mod` is launched with `--prompt` and `--tdd`, and the user picks a custom name for the dev deps entrypoint, the `.test.ts` file would still try to import the default from the settings (dev_deps.ts)
